### PR TITLE
feat: Update to use `broker` model (SC-74)

### DIFF
--- a/src/ArrangerConduit.sol
+++ b/src/ArrangerConduit.sol
@@ -82,7 +82,7 @@ contract ArrangerConduit is UpgradeableProxied, IArrangerConduit {
     }
 
     /**********************************************************************************************/
-    /*** Router Functions                                                                       ***/
+    /*** Operator Functions                                                                     ***/
     /**********************************************************************************************/
 
     function deposit(bytes32 ilk, address asset, uint256 amount) external override ilkAuth(ilk) {

--- a/src/ArrangerConduit.sol
+++ b/src/ArrangerConduit.sol
@@ -39,6 +39,8 @@ contract ArrangerConduit is UpgradeableProxied, IArrangerConduit {
     mapping(address => uint256) public override totalWithdrawableFunds;
     mapping(address => uint256) public override totalWithdrawals;
 
+    mapping(address => mapping(address => bool)) public override isBroker;
+
     mapping(bytes32 => mapping(address => uint256)) public override deposits;
     mapping(bytes32 => mapping(address => uint256)) public override requestedFunds;
     mapping(bytes32 => mapping(address => uint256)) public override withdrawableFunds;
@@ -72,6 +74,11 @@ contract ArrangerConduit is UpgradeableProxied, IArrangerConduit {
         else if (what == "roles")    roles    = data;
         else revert("ArrangerConduit/file-unrecognized-param");
         emit File(what, data);
+    }
+
+    function setBroker(address broker, address asset, bool valid) external auth {
+        isBroker[broker][asset] = valid;
+        emit SetBroker(broker, asset, valid);
     }
 
     /**********************************************************************************************/
@@ -159,12 +166,19 @@ contract ArrangerConduit is UpgradeableProxied, IArrangerConduit {
     /*** Fund Manager Functions                                                                 ***/
     /**********************************************************************************************/
 
-    function drawFunds(address asset, uint256 amount) external override isArranger {
-        require(amount <= drawableFunds(asset), "ArrangerConduit/insufficient-funds");
+    function drawFunds(
+        address asset,
+        address destination,
+        uint256 amount
+    )
+        external override isArranger
+    {
+        require(amount <= availableFunds(asset), "ArrangerConduit/insufficient-funds");
+        require(isBroker[destination][asset],    "ArrangerConduit/invalid-broker");
 
-        require(ERC20Like(asset).transfer(msg.sender, amount), "ArrangerConduit/transfer-failed");
+        require(ERC20Like(asset).transfer(destination, amount), "ArrangerConduit/transfer-failed");
 
-        emit DrawFunds(asset, amount);
+        emit DrawFunds(asset, destination, amount);
     }
 
     function returnFunds(uint256 fundRequestId, uint256 returnAmount)
@@ -172,15 +186,17 @@ contract ArrangerConduit is UpgradeableProxied, IArrangerConduit {
     {
         FundRequest storage fundRequest = fundRequests[fundRequestId];
 
-        require(fundRequest.status == StatusEnum.PENDING, "ArrangerConduit/invalid-status");
-
         address asset = fundRequest.asset;
-        bytes32 ilk   = fundRequest.ilk;
 
-        uint256 amountRequested = fundRequest.amountRequested;
+        require(fundRequest.status == StatusEnum.PENDING, "ArrangerConduit/invalid-status");
+        require(returnAmount <= availableFunds(asset),    "ArrangerConduit/insufficient-funds");
+
+        bytes32 ilk = fundRequest.ilk;
 
         withdrawableFunds[ilk][asset] += returnAmount;
         totalWithdrawableFunds[asset] += returnAmount;
+
+        uint256 amountRequested = fundRequest.amountRequested;
 
         requestedFunds[ilk][asset] -= amountRequested;
         totalRequestedFunds[asset] -= amountRequested;
@@ -189,11 +205,6 @@ contract ArrangerConduit is UpgradeableProxied, IArrangerConduit {
 
         fundRequest.status = StatusEnum.COMPLETED;
 
-        require(
-            ERC20Like(fundRequest.asset).transferFrom(msg.sender, address(this), returnAmount),
-            "ArrangerConduit/transfer-failed"
-        );
-
         emit ReturnFunds(ilk, asset, fundRequestId, amountRequested, returnAmount);
     }
 
@@ -201,8 +212,8 @@ contract ArrangerConduit is UpgradeableProxied, IArrangerConduit {
     /*** View Functions                                                                         ***/
     /**********************************************************************************************/
 
-    function drawableFunds(address asset) public view override returns (uint256 drawableFunds_) {
-        drawableFunds_ = ERC20Like(asset).balanceOf(address(this)) - totalWithdrawableFunds[asset];
+    function availableFunds(address asset) public view override returns (uint256 availableFunds_) {
+        availableFunds_ = ERC20Like(asset).balanceOf(address(this)) - totalWithdrawableFunds[asset];
     }
 
     function getFundRequest(uint256 fundRequestId)

--- a/src/interfaces/IArrangerConduit.sol
+++ b/src/interfaces/IArrangerConduit.sol
@@ -172,8 +172,8 @@ interface IArrangerConduit is IAllocatorConduit {
 
     /**
      *  @dev    Returns if an address is a valid broker for a given asset.
-     *  @param  broker    The address of the asset.
-     *  @param  asset     The total amount that can be withdrawn from the asset.
+     *  @param  broker    The address of the broker to check.
+     *  @param  asset     The address of the asset that the broker is valid for.
      *  @return isBroker_ Boolean value indicating if the broker is valid or not.
      */
     function isBroker(address broker, address asset) external view returns (bool isBroker_);
@@ -224,7 +224,7 @@ interface IArrangerConduit is IAllocatorConduit {
     function file(bytes32 what, address data) external;
 
     /**********************************************************************************************/
-    /*** Allocator Functions                                                                    ***/
+    /*** Operator Functions                                                                     ***/
     /**********************************************************************************************/
 
     /**
@@ -249,7 +249,8 @@ interface IArrangerConduit is IAllocatorConduit {
     /**********************************************************************************************/
 
     /**
-     * @notice Draw funds from the contract to the Arranger.
+     * @notice Draw funds from the contract to a `destination` that the Arranger specifies. This
+     *         destination MUST be a whitelisted `broker` address for the given `asset`.
      * @dev    Only the Arranger is authorized to call this function.
      * @param  asset       The ERC20 token contract address from which funds are being drawn.
      * @param  destination The destination to transfer the funds to.

--- a/src/interfaces/IArrangerConduit.sol
+++ b/src/interfaces/IArrangerConduit.sol
@@ -23,6 +23,14 @@ interface IArrangerConduit is IAllocatorConduit {
      */
     event File(bytes32 indexed what, address data);
 
+    /**
+     *  @dev   Event emitted when a broker is added or removed from the whitelist.
+     *  @param broker The address of the broker.
+     *  @param asset  The address of the asset.
+     *  @param valid  Boolean value indicating if the broker is whitelisted or not.
+     */
+    event SetBroker(address indexed broker, address indexed asset, bool valid);
+
     /**********************************************************************************************/
     /*** Fund Events                                                                            ***/
     /**********************************************************************************************/
@@ -35,10 +43,11 @@ interface IArrangerConduit is IAllocatorConduit {
 
     /**
      *  @dev   Event emitted when funds are drawn from the Conduit by the Arranger.
-     *  @param asset         The address of the asset to be withdrawn.
-     *  @param amount        The amount of asset to be withdrawn.
+     *  @param asset       The address of the asset to be withdrawn.
+     *  @param destination The address to transfer the funds to.
+     *  @param amount      The amount of asset to be withdrawn.
      */
-    event DrawFunds(address indexed asset, uint256 amount);
+    event DrawFunds(address indexed asset, address indexed destination, uint256 amount);
 
     /**
      *  @dev   Event emitted when a fund request is made.
@@ -162,6 +171,14 @@ interface IArrangerConduit is IAllocatorConduit {
         external view returns (uint256 totalWithdrawals_);
 
     /**
+     *  @dev    Returns if an address is a valid broker for a given asset.
+     *  @param  broker    The address of the asset.
+     *  @param  asset     The total amount that can be withdrawn from the asset.
+     *  @return isBroker_ Boolean value indicating if the broker is valid or not.
+     */
+    function isBroker(address broker, address asset) external view returns (bool isBroker_);
+
+    /**
      *  @dev    Returns the aggregate deposits for a given ilk and asset.
      *  @param  ilk        The unique identifier for a particular ilk.
      *  @param  asset      The address of the asset.
@@ -234,10 +251,11 @@ interface IArrangerConduit is IAllocatorConduit {
     /**
      * @notice Draw funds from the contract to the Arranger.
      * @dev    Only the Arranger is authorized to call this function.
-     * @param  asset  The ERC20 token contract address from which funds are being drawn.
-     * @param  amount The amount of tokens to be drawn.
+     * @param  asset       The ERC20 token contract address from which funds are being drawn.
+     * @param  destination The destination to transfer the funds to.
+     * @param  amount      The amount of tokens to be drawn.
      */
-    function drawFunds(address asset, uint256 amount) external;
+    function drawFunds(address asset, address destination, uint256 amount) external;
 
     /**
      * @notice Return funds (principal only) from the Arranger back to the contract.
@@ -254,10 +272,10 @@ interface IArrangerConduit is IAllocatorConduit {
 
     /**
      *  @dev    Function to get the amount of funds that can be drawn by the Arranger.
-     *  @param  asset          The asset to check.
-     *  @return drawableFunds_ The amount of funds that can be drawn by the Arranger.
+     *  @param  asset           The asset to check.
+     *  @return availableFunds_ The amount of funds that can be drawn by the Arranger.
      */
-    function drawableFunds(address asset) external view returns (uint256 drawableFunds_);
+    function availableFunds(address asset) external view returns (uint256 availableFunds_);
 
     /**
      *  @dev    Returns a FundRequest struct at a given fundRequestId.

--- a/test/arranger-conduit/AuthFunctions.t.sol
+++ b/test/arranger-conduit/AuthFunctions.t.sol
@@ -36,4 +36,32 @@ contract ArrangerConduit_AuthTests is ConduitTestBase {
         assertEq(conduitProxy.implementation(), newImplementation);
     }
 
+    function test_setBroker_noAuth() external {
+        vm.prank(makeAddr("non-admin"));
+        vm.expectRevert("ArrangerConduit/not-authorized");
+        conduit.setBroker(makeAddr("broker"), makeAddr("asset"), true);
+    }
+
+    function test_setBroker() external {
+        address asset1  = makeAddr("asset1");
+        address asset2  = makeAddr("asset2");
+        address broker1 = makeAddr("broker1");
+        address broker2 = makeAddr("broker2");
+
+        _assertBrokerSetter(broker1, asset1);
+        _assertBrokerSetter(broker1, asset2);
+        _assertBrokerSetter(broker2, asset1);
+        _assertBrokerSetter(broker2, asset2);
+    }
+
+    function _assertBrokerSetter(address broker, address asset) internal {
+        assertTrue(!conduit.isBroker(broker, asset));
+
+        conduit.setBroker(broker, asset, true);
+
+        assertTrue(conduit.isBroker(broker, asset));
+
+        conduit.setBroker(broker, asset, false);
+    }
+
 }

--- a/test/arranger-conduit/AuthFunctions.t.sol
+++ b/test/arranger-conduit/AuthFunctions.t.sol
@@ -62,6 +62,8 @@ contract ArrangerConduit_AuthTests is ConduitTestBase {
         assertTrue(conduit.isBroker(broker, asset));
 
         conduit.setBroker(broker, asset, false);
+
+        assertTrue(!conduit.isBroker(broker, asset));
     }
 
 }

--- a/test/arranger-conduit/CancelFundRequest.t.sol
+++ b/test/arranger-conduit/CancelFundRequest.t.sol
@@ -49,17 +49,16 @@ contract ArrangerConduit_RequestFundsFailureTests is ConduitAssetTestBase {
         vm.stopPrank();
 
         vm.prank(arranger);
-        conduit.drawFunds(address(asset), 100);
+        conduit.drawFunds(address(asset), broker, 100);
 
         vm.prank(operator);
         conduit.requestFunds(ilk, address(asset), 100, "info");
 
-        vm.startPrank(arranger);
+        vm.prank(broker);
+        asset.transfer(address(conduit), 100);
 
-        asset.approve(address(conduit), 100);
+        vm.prank(arranger);
         conduit.returnFunds(0, 100);
-
-        vm.stopPrank();
 
         vm.prank(operator);
         vm.expectRevert("ArrangerConduit/invalid-status");

--- a/test/arranger-conduit/ConduitTestBase.sol
+++ b/test/arranger-conduit/ConduitTestBase.sol
@@ -47,6 +47,8 @@ contract ConduitAssetTestBase is ConduitTestBase {
 
     uint8 ROLE = 0;
 
+    address broker = makeAddr("broker");
+
     bytes32 ilk = "ilk";
 
     MockERC20 asset = new MockERC20("asset", "ASSET", 18);
@@ -57,6 +59,8 @@ contract ConduitAssetTestBase is ConduitTestBase {
         _setupOperatorRole(ilk, operator);
 
         registry.file(ilk, "buffer", operator);
+
+        conduit.setBroker(broker, address(asset), true);
     }
 
     function _assertInvariants(bytes32 ilk_, address asset_) internal {
@@ -100,11 +104,7 @@ contract ConduitAssetTestBase is ConduitTestBase {
         conduit.deposit(ilk_, address(asset_), amount);
 
         vm.startPrank(arranger);
-        conduit.drawFunds(address(asset_), amount);
-
-        uint256 allowance = asset.allowance(operator_, address(conduit));
-
-        asset_.approve(address(conduit), allowance + amount);
+        conduit.drawFunds(address(asset_), broker, amount);
 
         vm.stopPrank();
     }

--- a/test/arranger-conduit/DrawFunds.t.sol
+++ b/test/arranger-conduit/DrawFunds.t.sol
@@ -23,6 +23,13 @@ contract ArrangerConduit_drawFundsTests is ConduitAssetTestBase {
         conduit.drawFunds(address(asset), broker, 100);
     }
 
+    function test_drawFunds_invalidBroker() external {
+        vm.startPrank(arranger);
+
+        vm.expectRevert("ArrangerConduit/invalid-broker");
+        conduit.drawFunds(address(asset), makeAddr("non-broker"), 100);
+    }
+
     function test_drawFunds_insufficientDrawableBoundary() external {
         assertEq(conduit.availableFunds(address(asset)), 100);
 
@@ -37,7 +44,7 @@ contract ArrangerConduit_drawFundsTests is ConduitAssetTestBase {
     function test_drawFunds_transferRevert() external {
         vm.mockCall(
             address(asset),
-            abi.encodeWithSelector(asset.transfer.selector, arranger, 0),
+            abi.encodeWithSelector(asset.transfer.selector, broker, 0),
             abi.encode(false)
         );
 
@@ -50,7 +57,7 @@ contract ArrangerConduit_drawFundsTests is ConduitAssetTestBase {
         assertEq(conduit.availableFunds(address(asset)), 100);
 
         assertEq(asset.balanceOf(address(conduit)), 100);
-        assertEq(asset.balanceOf(arranger),         0);
+        assertEq(asset.balanceOf(broker),           0);
 
         vm.prank(arranger);
         conduit.drawFunds(address(asset), broker, 40);
@@ -58,7 +65,7 @@ contract ArrangerConduit_drawFundsTests is ConduitAssetTestBase {
         assertEq(conduit.availableFunds(address(asset)), 60);
 
         assertEq(asset.balanceOf(address(conduit)), 60);
-        assertEq(asset.balanceOf(arranger),         40);
+        assertEq(asset.balanceOf(broker),           40);
 
         _assertInvariants(ilk, address(asset));
     }

--- a/test/arranger-conduit/DrawFunds.t.sol
+++ b/test/arranger-conduit/DrawFunds.t.sol
@@ -20,18 +20,18 @@ contract ArrangerConduit_drawFundsTests is ConduitAssetTestBase {
 
     function test_drawFunds_notArranger() external {
         vm.expectRevert("ArrangerConduit/not-arranger");
-        conduit.drawFunds(address(asset), 100);
+        conduit.drawFunds(address(asset), broker, 100);
     }
 
     function test_drawFunds_insufficientDrawableBoundary() external {
-        assertEq(conduit.drawableFunds(address(asset)), 100);
+        assertEq(conduit.availableFunds(address(asset)), 100);
 
         vm.startPrank(arranger);
 
         vm.expectRevert("ArrangerConduit/insufficient-funds");
-        conduit.drawFunds(address(asset), 101);
+        conduit.drawFunds(address(asset), broker, 101);
 
-        conduit.drawFunds(address(asset), 100);
+        conduit.drawFunds(address(asset), broker, 100);
     }
 
     function test_drawFunds_transferRevert() external {
@@ -43,19 +43,19 @@ contract ArrangerConduit_drawFundsTests is ConduitAssetTestBase {
 
         vm.prank(arranger);
         vm.expectRevert("ArrangerConduit/transfer-failed");
-        conduit.drawFunds(address(asset), 0);
+        conduit.drawFunds(address(asset), broker, 0);
     }
 
     function test_drawFunds() public {
-        assertEq(conduit.drawableFunds(address(asset)), 100);
+        assertEq(conduit.availableFunds(address(asset)), 100);
 
         assertEq(asset.balanceOf(address(conduit)), 100);
         assertEq(asset.balanceOf(arranger),         0);
 
         vm.prank(arranger);
-        conduit.drawFunds(address(asset), 40);
+        conduit.drawFunds(address(asset), broker, 40);
 
-        assertEq(conduit.drawableFunds(address(asset)), 60);
+        assertEq(conduit.availableFunds(address(asset)), 60);
 
         assertEq(asset.balanceOf(address(conduit)), 60);
         assertEq(asset.balanceOf(arranger),         40);

--- a/test/arranger-conduit/EventsData.t.sol
+++ b/test/arranger-conduit/EventsData.t.sol
@@ -7,7 +7,7 @@ contract ArrangerConduit_WithdrawTests is ConduitAssetTestBase {
 
     event CancelFundRequest(uint256 fundRequestId);
     event Deposit(bytes32 indexed ilk, address indexed asset, address origin, uint256 amount);
-    event DrawFunds(address indexed asset, uint256 amount);
+    event DrawFunds(address indexed asset, address indexed destination, uint256 amount);
     event RequestFunds(
         bytes32 indexed ilk,
         address indexed asset,
@@ -69,8 +69,8 @@ contract ArrangerConduit_WithdrawTests is ConduitAssetTestBase {
 
         vm.prank(arranger);
         vm.expectEmit(address(conduit));
-        emit DrawFunds(address(asset), 40);
-        conduit.drawFunds(address(asset), 40);
+        emit DrawFunds(address(asset), broker, 40);
+        conduit.drawFunds(address(asset), broker, 40);
     }
 
     function test_file() public {
@@ -108,7 +108,7 @@ contract ArrangerConduit_WithdrawTests is ConduitAssetTestBase {
         vm.stopPrank();
 
         vm.prank(arranger);
-        conduit.drawFunds(address(asset), 100);
+        conduit.drawFunds(address(asset), broker, 100);
 
         vm.prank(operator);
         conduit.requestFunds(ilk, address(asset), 20, "info");

--- a/test/arranger-conduit/EventsData.t.sol
+++ b/test/arranger-conduit/EventsData.t.sol
@@ -110,6 +110,8 @@ contract ArrangerConduit_WithdrawTests is ConduitAssetTestBase {
         vm.prank(arranger);
         conduit.drawFunds(address(asset), broker, 100);
 
+        asset.mint(address(conduit), 100);
+
         vm.prank(operator);
         conduit.requestFunds(ilk, address(asset), 20, "info");
 
@@ -141,6 +143,8 @@ contract ArrangerConduit_WithdrawTests is ConduitAssetTestBase {
 
         vm.prank(operator);
         conduit.requestFunds(ilk, address(asset), 100, "info");
+
+        asset.mint(address(conduit), 100);
 
         vm.prank(arranger);
         conduit.returnFunds(0, 100);

--- a/test/arranger-conduit/ReturnFunds.t.sol
+++ b/test/arranger-conduit/ReturnFunds.t.sol
@@ -18,7 +18,7 @@ contract ArrangerConduit_ReturnFundsTests is ConduitAssetTestBase {
         vm.stopPrank();
 
         vm.prank(arranger);
-        conduit.drawFunds(address(asset), 100);
+        conduit.drawFunds(address(asset), broker, 100);
 
         vm.prank(operator);
         conduit.requestFunds(ilk, address(asset), 100, "info");
@@ -85,7 +85,7 @@ contract ArrangerConduit_ReturnFundsTests is ConduitAssetTestBase {
         vm.stopPrank();
 
         vm.prank(arranger);
-        conduit.drawFunds(address(asset), 100);
+        conduit.drawFunds(address(asset), broker, 100);
 
         vm.prank(operator);
         conduit.requestFunds(ilk, address(asset), 100, "info");
@@ -155,7 +155,7 @@ contract ArrangerConduit_ReturnFundsTests is ConduitAssetTestBase {
         vm.stopPrank();
 
         vm.prank(arranger);
-        conduit.drawFunds(address(asset), 100);
+        conduit.drawFunds(address(asset), broker, 100);
 
         vm.prank(operator);
         conduit.requestFunds(ilk, address(asset), 100, "info");
@@ -215,7 +215,7 @@ contract ArrangerConduit_ReturnFundsTests is ConduitAssetTestBase {
         vm.stopPrank();
 
         vm.prank(arranger);
-        conduit.drawFunds(address(asset), 100);
+        conduit.drawFunds(address(asset), broker, 100);
 
         vm.startPrank(operator);
 
@@ -326,7 +326,7 @@ contract ArrangerConduit_ReturnFundsTests is ConduitAssetTestBase {
         vm.stopPrank();
 
         vm.prank(arranger);
-        conduit.drawFunds(address(asset), 100);
+        conduit.drawFunds(address(asset), broker, 100);
 
         vm.prank(operator1);
         conduit.requestFunds(ilk1, address(asset), 40, "info");
@@ -410,6 +410,9 @@ contract ArrangerConduit_ReturnFundsTests is ConduitAssetTestBase {
         bytes32 ilk1 = "ilk1";
         bytes32 ilk2 = "ilk2";
 
+        address broker1 = makeAddr("broker1");
+        address broker2 = makeAddr("broker2");
+
         address operator1 = makeAddr("operator1");
         address operator2 = makeAddr("operator2");
 
@@ -447,8 +450,8 @@ contract ArrangerConduit_ReturnFundsTests is ConduitAssetTestBase {
 
         vm.startPrank(arranger);
 
-        conduit.drawFunds(address(asset1), 100);
-        conduit.drawFunds(address(asset2), 400);
+        conduit.drawFunds(address(asset1), broker1, 100);
+        conduit.drawFunds(address(asset2), broker2, 400);
 
         vm.stopPrank();
 

--- a/test/arranger-conduit/ViewFunctions.t.sol
+++ b/test/arranger-conduit/ViewFunctions.t.sol
@@ -42,11 +42,11 @@ contract ArrangerConduit_DrawableFundsTest is ConduitAssetTestBase {
         conduitHarness.__setTotalWithdrawableFunds(address(asset2), withdrawableFundsAmount2);
 
         assertEq(
-            conduitHarness.drawableFunds(address(asset1)),
+            conduitHarness.availableFunds(address(asset1)),
             asset1.balanceOf(address(conduitHarness)) - withdrawableFundsAmount1
         );
         assertEq(
-            conduitHarness.drawableFunds(address(asset2)),
+            conduitHarness.availableFunds(address(asset2)),
             asset2.balanceOf(address(conduitHarness)) - withdrawableFundsAmount2
         );
     }
@@ -114,7 +114,7 @@ contract ArrangerConduit_GetFundRequestsLengthTest is ConduitAssetTestBase {
 
         vm.startPrank(arranger);
 
-        conduit.drawFunds(address(asset), 100);
+        conduit.drawFunds(address(asset), broker, 100);
         asset.approve(address(conduit), 100);
         conduit.returnFunds(0, 40);
 

--- a/test/arranger-conduit/ViewFunctions.t.sol
+++ b/test/arranger-conduit/ViewFunctions.t.sol
@@ -115,7 +115,7 @@ contract ArrangerConduit_GetFundRequestsLengthTest is ConduitAssetTestBase {
         vm.startPrank(arranger);
 
         conduit.drawFunds(address(asset), broker, 100);
-        asset.approve(address(conduit), 100);
+        asset.mint(address(conduit), 100);
         conduit.returnFunds(0, 40);
 
         assertEq(conduit.getFundRequestsLength(), 2);  // Returning funds does not change length

--- a/test/arranger-conduit/Withdraw.t.sol
+++ b/test/arranger-conduit/Withdraw.t.sol
@@ -41,6 +41,8 @@ contract ArrangerConduit_WithdrawTests is ConduitAssetTestBase {
         vm.prank(operator);
         conduit.requestFunds(ilk, address(asset), 100, "info");
 
+        asset.mint(address(conduit), 100);
+
         vm.prank(arranger);
         conduit.returnFunds(0, 100);
 
@@ -88,9 +90,10 @@ contract ArrangerConduit_WithdrawTests is ConduitAssetTestBase {
         vm.prank(operator2);
         conduit.requestFunds(ilk2, address(asset), 400, "info");
 
+        asset.mint(address(conduit), 500);
+
         vm.startPrank(arranger);
 
-        asset.approve(address(conduit), 500);
         conduit.returnFunds(0, 200);  // Over by 100
         conduit.returnFunds(1, 300);  // Under by 100
 


### PR DESCRIPTION
This PR:
- Adds a mapping `isBroker` that allows configuration of whitelisted brokers for each asset
- Allows for the `arranger` to specify a `destination` to send funds to during a `drawFunds` call, which has to be a valid `broker` for that asset
- Removes pull pattern from `returnFunds`, instead accounts for `availableFunds` (unencumbered funds). This allows for `brokers` to `transfer` into the conduit directly.