### PR TITLE
feat: Update to use buffer structure, make all necessary test changes (SC-185)

### DIFF
--- a/test/arranger-conduit/CancelFundRequest.t.sol
+++ b/test/arranger-conduit/CancelFundRequest.t.sol
@@ -5,16 +5,15 @@ import { IArrangerConduit } from "../../src/interfaces/IArrangerConduit.sol";
 
 import "./ConduitTestBase.sol";
 
-contract ArrangerConduit_RequestFundsFailureTests is ConduitAssetTestBase {
+contract ArrangerConduit_CancelFundRequestFailureTests is ConduitAssetTestBase {
 
     function test_cancelFundRequest_noIlkAuth() public {
-        asset.mint(operator, 100);
+        asset1.mint(buffer1, 100);
 
-        vm.startPrank(operator);
+        vm.startPrank(operator1);
 
-        asset.approve(address(conduit), 100);
-        conduit.deposit(ilk, address(asset), 100);
-        conduit.requestFunds(ilk, address(asset), 100, "info");
+        conduit.deposit(ilk1, address(asset1), 100);
+        conduit.requestFunds(ilk1, address(asset1), 100, "info");
 
         vm.stopPrank();
 
@@ -24,14 +23,10 @@ contract ArrangerConduit_RequestFundsFailureTests is ConduitAssetTestBase {
     }
 
     function test_cancelFundRequest_notInitialized() public {
-        asset.mint(operator, 100);
+        asset1.mint(buffer1, 100);
 
-        vm.startPrank(operator);
-
-        asset.approve(address(conduit), 100);
-        conduit.deposit(ilk, address(asset), 100);
-
-        vm.stopPrank();
+        vm.prank(operator1);
+        conduit.deposit(ilk1, address(asset1), 100);
 
         vm.prank(arranger);
         vm.expectRevert(stdError.indexOOBError);
@@ -39,41 +34,35 @@ contract ArrangerConduit_RequestFundsFailureTests is ConduitAssetTestBase {
     }
 
     function test_cancelFundRequest_completed() public {
-        asset.mint(operator, 100);
+        asset1.mint(buffer1, 100);
 
-        vm.startPrank(operator);
-
-        asset.approve(address(conduit), 100);
-        conduit.deposit(ilk, address(asset), 100);
-
-        vm.stopPrank();
+        vm.prank(operator1);
+        conduit.deposit(ilk1, address(asset1), 100);
 
         vm.prank(arranger);
-        conduit.drawFunds(address(asset), broker, 100);
+        conduit.drawFunds(address(asset1), broker1, 100);
 
-        vm.prank(operator);
-        conduit.requestFunds(ilk, address(asset), 100, "info");
+        vm.prank(operator1);
+        conduit.requestFunds(ilk1, address(asset1), 100, "info");
 
-        vm.prank(broker);
-        asset.transfer(address(conduit), 100);
+        vm.prank(broker1);
+        asset1.transfer(address(conduit), 100);
 
         vm.prank(arranger);
         conduit.returnFunds(0, 100);
 
-        vm.prank(operator);
+        vm.prank(operator1);
         vm.expectRevert("ArrangerConduit/invalid-status");
         conduit.cancelFundRequest(0);
     }
 
     function test_cancelFundRequest_cancelled() public {
-        asset.mint(operator, 100);
+        asset1.mint(buffer1, 100);
 
-        vm.startPrank(operator);
+        vm.startPrank(operator1);
 
-        asset.approve(address(conduit), 100);
-
-        conduit.deposit(ilk, address(asset), 100);
-        conduit.requestFunds(ilk, address(asset), 100, "info");
+        conduit.deposit(ilk1, address(asset1), 100);
+        conduit.requestFunds(ilk1, address(asset1), 100, "info");
         conduit.cancelFundRequest(0);
 
         vm.expectRevert("ArrangerConduit/invalid-status");
@@ -82,31 +71,30 @@ contract ArrangerConduit_RequestFundsFailureTests is ConduitAssetTestBase {
 
 }
 
-contract ArrangerConduit_RequestFundsTests is ConduitAssetTestBase {
+contract ArrangerConduit_CancelFundRequestTests is ConduitAssetTestBase {
 
     function test_cancelFundRequest() public {
-        asset.mint(operator, 100);
+        asset1.mint(buffer1, 100);
 
-        vm.startPrank(operator);
+        vm.startPrank(operator1);
 
-        asset.approve(address(conduit), 100);
-        conduit.deposit(ilk, address(asset), 100);
-        conduit.requestFunds(ilk, address(asset), 100, "info");
+        conduit.deposit(ilk1, address(asset1), 100);
+        conduit.requestFunds(ilk1, address(asset1), 100, "info");
 
         IArrangerConduit.FundRequest memory fundRequest = conduit.getFundRequest(0);
 
         assertTrue(fundRequest.status == IArrangerConduit.StatusEnum.PENDING);
 
-        assertEq(fundRequest.asset,           address(asset));
-        assertEq(fundRequest.ilk,             ilk);
+        assertEq(fundRequest.asset,           address(asset1));
+        assertEq(fundRequest.ilk,             ilk1);
         assertEq(fundRequest.amountRequested, 100);
         assertEq(fundRequest.amountFilled,    0);
         assertEq(fundRequest.info,            "info");
 
-        assertEq(conduit.requestedFunds(address(asset), ilk), 100);
-        assertEq(conduit.totalRequestedFunds(address(asset)), 100);
+        assertEq(conduit.requestedFunds(address(asset1), ilk1), 100);
+        assertEq(conduit.totalRequestedFunds(address(asset1)), 100);
 
-        _assertInvariants(ilk, address(asset));
+        _assertInvariants();
 
         conduit.cancelFundRequest(0);
 
@@ -114,16 +102,16 @@ contract ArrangerConduit_RequestFundsTests is ConduitAssetTestBase {
 
         assertTrue(fundRequest.status == IArrangerConduit.StatusEnum.CANCELLED);
 
-        assertEq(fundRequest.asset,           address(asset));
-        assertEq(fundRequest.ilk,             ilk);
+        assertEq(fundRequest.asset,           address(asset1));
+        assertEq(fundRequest.ilk,             ilk1);
         assertEq(fundRequest.amountRequested, 100);
         assertEq(fundRequest.amountFilled,    0);
         assertEq(fundRequest.info,            "info");
 
-        assertEq(conduit.requestedFunds(address(asset), ilk), 0);
-        assertEq(conduit.totalRequestedFunds(address(asset)), 0);
+        assertEq(conduit.requestedFunds(address(asset1), ilk1), 0);
+        assertEq(conduit.totalRequestedFunds(address(asset1)),  0);
 
-        _assertInvariants(ilk, address(asset));
+        _assertInvariants();
     }
 
 }

--- a/test/arranger-conduit/ConduitTestBase.sol
+++ b/test/arranger-conduit/ConduitTestBase.sol
@@ -132,7 +132,7 @@ contract ConduitAssetTestBase is ConduitTestBase {
     }
 
     function _setupOperatorRole(bytes32 ilk_, address operator_) internal {
-        // Ensure address(this) can always set for a new ilk1
+        // Ensure address(this) can always set for a new ilk
         roles.setIlkAdmin(ilk_, address(this));
 
         roles.setUserRole(ilk_, operator_, ROLE, true);

--- a/test/arranger-conduit/ConduitTestBase.sol
+++ b/test/arranger-conduit/ConduitTestBase.sol
@@ -67,8 +67,6 @@ contract ConduitAssetTestBase is ConduitTestBase {
         registry.file(ilk2, "buffer", buffer2);
 
         conduit.setBroker(broker1, address(asset1), true);
-        conduit.setBroker(broker1, address(asset2), true);
-        conduit.setBroker(broker2, address(asset1), true);
         conduit.setBroker(broker2, address(asset2), true);
 
         vm.startPrank(buffer1);
@@ -114,7 +112,7 @@ contract ConduitAssetTestBase is ConduitTestBase {
         address   operator_,
         address   buffer_,
         address   broker_,
-        bytes32   ilk1_,
+        bytes32   ilk_,
         uint256   amount
     )
         internal
@@ -122,7 +120,7 @@ contract ConduitAssetTestBase is ConduitTestBase {
         asset_.mint(buffer_, amount);
 
         vm.prank(operator_);
-        conduit.deposit(ilk1_, address(asset_), amount);
+        conduit.deposit(ilk_, address(asset_), amount);
 
         vm.prank(arranger);
         conduit.drawFunds(address(asset_), broker_, amount);
@@ -133,18 +131,18 @@ contract ConduitAssetTestBase is ConduitTestBase {
         _depositAndDrawFunds(asset1, operator1, buffer1, broker1, ilk1, amount);
     }
 
-    function _setupOperatorRole(bytes32 ilk1_, address operator_) internal {
+    function _setupOperatorRole(bytes32 ilk_, address operator_) internal {
         // Ensure address(this) can always set for a new ilk1
-        roles.setIlkAdmin(ilk1_, address(this));
+        roles.setIlkAdmin(ilk_, address(this));
 
-        roles.setUserRole(ilk1_, operator_, ROLE, true);
+        roles.setUserRole(ilk_, operator_, ROLE, true);
 
         address conduit_ = address(conduit);
 
-        roles.setRoleAction(ilk1_, ROLE, conduit_, conduit.deposit.selector,           true);
-        roles.setRoleAction(ilk1_, ROLE, conduit_, conduit.withdraw.selector,          true);
-        roles.setRoleAction(ilk1_, ROLE, conduit_, conduit.requestFunds.selector,      true);
-        roles.setRoleAction(ilk1_, ROLE, conduit_, conduit.cancelFundRequest.selector, true);
+        roles.setRoleAction(ilk_, ROLE, conduit_, conduit.deposit.selector,           true);
+        roles.setRoleAction(ilk_, ROLE, conduit_, conduit.withdraw.selector,          true);
+        roles.setRoleAction(ilk_, ROLE, conduit_, conduit.requestFunds.selector,      true);
+        roles.setRoleAction(ilk_, ROLE, conduit_, conduit.cancelFundRequest.selector, true);
     }
 
 }

--- a/test/arranger-conduit/Deposit.t.sol
+++ b/test/arranger-conduit/Deposit.t.sol
@@ -6,76 +6,74 @@ import "./ConduitTestBase.sol";
 contract ArrangerConduit_DepositFailureTests is ConduitAssetTestBase {
 
     function test_deposit_noIlkAuth() public {
-        asset.mint(operator, 100);
-
-        asset.approve(address(conduit), 100);
+        asset1.mint(buffer1, 100);
 
         vm.expectRevert("ArrangerConduit/not-authorized");
-        conduit.deposit(ilk, address(asset), 100);
+        conduit.deposit(ilk1, address(asset1), 100);
     }
 
     function test_deposit_insufficientApproveBoundary() public {
-        asset.mint(operator, 100);
+        asset1.mint(buffer1, 100);
 
-        vm.startPrank(operator);
+        vm.prank(buffer1);
+        asset1.approve(address(conduit), 99);
 
-        asset.approve(address(conduit), 99);
-
+        vm.prank(operator1);
         vm.expectRevert(stdError.arithmeticError);
-        conduit.deposit(ilk, address(asset), 100);
+        conduit.deposit(ilk1, address(asset1), 100);
 
-        asset.approve(address(conduit), 100);
+        vm.prank(buffer1);
+        asset1.approve(address(conduit), 100);
 
-        conduit.deposit(ilk, address(asset), 100);
+        vm.prank(operator1);
+        conduit.deposit(ilk1, address(asset1), 100);
     }
 
     function testFuzz_deposit_insufficientApproveBoundary(uint256 amount) public {
         vm.assume(amount != 0);
 
-        asset.mint(operator, amount);
+        asset1.mint(buffer1, amount);
 
-        vm.startPrank(operator);
+        vm.prank(buffer1);
+        asset1.approve(address(conduit), amount - 1);
 
-        asset.approve(address(conduit), amount - 1);
-
+        vm.prank(operator1);
         vm.expectRevert(stdError.arithmeticError);
-        conduit.deposit(ilk, address(asset), amount);
+        conduit.deposit(ilk1, address(asset1), amount);
 
-        asset.approve(address(conduit), amount);
+        vm.prank(buffer1);
+        asset1.approve(address(conduit), amount);
 
-        conduit.deposit(ilk, address(asset), amount);
+        vm.prank(operator1);
+        conduit.deposit(ilk1, address(asset1), amount);
     }
 
     function test_deposit_insufficientFundsBoundary() public {
-        asset.mint(operator, 99);
+        asset1.mint(buffer1, 99);
 
-        vm.startPrank(operator);
-
-        asset.approve(address(conduit), 100);
+        vm.startPrank(operator1);
 
         vm.expectRevert(stdError.arithmeticError);
-        conduit.deposit(ilk, address(asset), 100);
+        conduit.deposit(ilk1, address(asset1), 100);
 
-        asset.mint(operator, 1);
+        asset1.mint(buffer1, 1);
 
-        conduit.deposit(ilk, address(asset), 100);
+        conduit.deposit(ilk1, address(asset1), 100);
     }
 
     function testFuzz_deposit_insufficientFundsBoundary(uint256 amount) public {
         vm.assume(amount != 0);
 
-        asset.mint(operator, amount - 1);
+        asset1.mint(buffer1, amount - 1);
 
-        vm.startPrank(operator);
-
-        asset.approve(address(conduit), amount);
+        vm.startPrank(operator1);
 
         vm.expectRevert(stdError.arithmeticError);
-        conduit.deposit(ilk, address(asset), amount);
+        conduit.deposit(ilk1, address(asset1), amount);
 
-        asset.mint(operator, 1);
+        asset1.mint(buffer1, 1);
 
-        conduit.deposit(ilk, address(asset), amount);
+        conduit.deposit(ilk1, address(asset1), amount);
     }
 
 }
@@ -83,110 +81,86 @@ contract ArrangerConduit_DepositFailureTests is ConduitAssetTestBase {
 contract ArrangerConduit_DepositTests is ConduitAssetTestBase {
 
     function test_deposit_singleIlk() external {
-        asset.mint(operator, 100);
-
-        vm.startPrank(operator);
-
-        asset.approve(address(conduit), 100);
-
-        assertEq(asset.balanceOf(operator),         100);
-        assertEq(asset.balanceOf(address(conduit)), 0);
-
-        assertEq(conduit.deposits(address(asset), ilk), 0);
-        assertEq(conduit.totalDeposits(address(asset)), 0);
-
-        conduit.deposit(ilk, address(asset), 100);
-
-        assertEq(asset.balanceOf(operator),         0);
-        assertEq(asset.balanceOf(address(conduit)), 100);
-
-        assertEq(conduit.deposits(address(asset), ilk), 100);
-        assertEq(conduit.totalDeposits(address(asset)), 100);
-
-        _assertInvariants(ilk, address(asset));
-    }
-
-    function testFuzz_deposit_singleIlk(uint256 amount) external {
-        asset.mint(operator, amount);
-
-        vm.startPrank(operator);
-
-        asset.approve(address(conduit), amount);
-
-        assertEq(asset.balanceOf(operator),         amount);
-        assertEq(asset.balanceOf(address(conduit)), 0);
-
-        assertEq(conduit.deposits(address(asset), ilk), 0);
-        assertEq(conduit.totalDeposits(address(asset)), 0);
-
-        conduit.deposit(ilk, address(asset), amount);
-
-        assertEq(asset.balanceOf(operator),         0);
-        assertEq(asset.balanceOf(address(conduit)), amount);
-
-        assertEq(conduit.deposits(address(asset), ilk), amount);
-        assertEq(conduit.totalDeposits(address(asset)), amount);
-
-        _assertInvariants(ilk, address(asset));
-    }
-
-    function test_deposit_multiIlk() external {
-        bytes32 ilk1 = "ilk1";
-        bytes32 ilk2 = "ilk2";
-
-        address operator1 = makeAddr("operator1");
-        address operator2 = makeAddr("operator2");
-
-        _setupOperatorRole(ilk1, operator1);
-        _setupOperatorRole(ilk2, operator2);
-
-        registry.file(ilk1, "buffer", operator1);
-        registry.file(ilk2, "buffer", operator2);
-
-        asset.mint(operator1, 100);
-        asset.mint(operator2, 300);
-
-        assertEq(asset.balanceOf(operator1),        100);
-        assertEq(asset.balanceOf(operator2),        300);
-        assertEq(asset.balanceOf(address(conduit)), 0);
-
-        assertEq(conduit.deposits(address(asset), ilk1), 0);
-        assertEq(conduit.deposits(address(asset), ilk2), 0);
-        assertEq(conduit.totalDeposits(address(asset)),  0);
+        asset1.mint(buffer1, 100);
 
         vm.startPrank(operator1);
 
-        asset.approve(address(conduit), 100);
-        conduit.deposit(ilk1, address(asset), 100);
+        assertEq(asset1.balanceOf(buffer1),          100);
+        assertEq(asset1.balanceOf(address(conduit)), 0);
 
-        vm.stopPrank();
+        assertEq(conduit.deposits(address(asset1), ilk1), 0);
+        assertEq(conduit.totalDeposits(address(asset1)),  0);
 
-        assertEq(asset.balanceOf(operator1),        0);
-        assertEq(asset.balanceOf(operator2),        300);
-        assertEq(asset.balanceOf(address(conduit)), 100);
+        conduit.deposit(ilk1, address(asset1), 100);
 
-        assertEq(conduit.deposits(address(asset), ilk1), 100);
-        assertEq(conduit.deposits(address(asset), ilk2), 0);
-        assertEq(conduit.totalDeposits(address(asset)),  100);
+        assertEq(asset1.balanceOf(buffer1),          0);
+        assertEq(asset1.balanceOf(address(conduit)), 100);
 
-        _assertInvariants(ilk1, ilk2, address(asset));
+        assertEq(conduit.deposits(address(asset1), ilk1), 100);
+        assertEq(conduit.totalDeposits(address(asset1)),  100);
 
-        vm.startPrank(operator2);
+        _assertInvariants();
+    }
 
-        asset.approve(address(conduit), 300);
-        conduit.deposit(ilk2, address(asset), 300);
+    function testFuzz_deposit_singleIlk(uint256 amount) external {
+        asset1.mint(buffer1, amount);
 
-        vm.stopPrank();
+        vm.startPrank(operator1);
 
-        assertEq(asset.balanceOf(operator1),        0);
-        assertEq(asset.balanceOf(operator2),        0);
-        assertEq(asset.balanceOf(address(conduit)), 400);
+        assertEq(asset1.balanceOf(buffer1),          amount);
+        assertEq(asset1.balanceOf(address(conduit)), 0);
 
-        assertEq(conduit.deposits(address(asset), ilk1), 100);
-        assertEq(conduit.deposits(address(asset), ilk2), 300);
-        assertEq(conduit.totalDeposits(address(asset)),  400);
+        assertEq(conduit.deposits(address(asset1), ilk1), 0);
+        assertEq(conduit.totalDeposits(address(asset1)),  0);
 
-        _assertInvariants(ilk1, ilk2, address(asset));
+        conduit.deposit(ilk1, address(asset1), amount);
+
+        assertEq(asset1.balanceOf(buffer1),          0);
+        assertEq(asset1.balanceOf(address(conduit)), amount);
+
+        assertEq(conduit.deposits(address(asset1), ilk1), amount);
+        assertEq(conduit.totalDeposits(address(asset1)),  amount);
+
+        _assertInvariants();
+    }
+
+    function test_deposit_multiIlk() external {
+        asset1.mint(buffer1, 100);
+        asset1.mint(buffer2, 300);
+
+        assertEq(asset1.balanceOf(buffer1),          100);
+        assertEq(asset1.balanceOf(buffer2),          300);
+        assertEq(asset1.balanceOf(address(conduit)), 0);
+
+        assertEq(conduit.deposits(address(asset1), ilk1), 0);
+        assertEq(conduit.deposits(address(asset1), ilk2), 0);
+        assertEq(conduit.totalDeposits(address(asset1)),  0);
+
+        vm.prank(operator1);
+        conduit.deposit(ilk1, address(asset1), 100);
+
+        assertEq(asset1.balanceOf(buffer1),          0);
+        assertEq(asset1.balanceOf(buffer2),          300);
+        assertEq(asset1.balanceOf(address(conduit)), 100);
+
+        assertEq(conduit.deposits(address(asset1), ilk1), 100);
+        assertEq(conduit.deposits(address(asset1), ilk2), 0);
+        assertEq(conduit.totalDeposits(address(asset1)),  100);
+
+        _assertInvariants();
+
+        vm.prank(operator2);
+        conduit.deposit(ilk2, address(asset1), 300);
+
+        assertEq(asset1.balanceOf(buffer1),          0);
+        assertEq(asset1.balanceOf(buffer2),          0);
+        assertEq(asset1.balanceOf(address(conduit)), 400);
+
+        assertEq(conduit.deposits(address(asset1), ilk1), 100);
+        assertEq(conduit.deposits(address(asset1), ilk2), 300);
+        assertEq(conduit.totalDeposits(address(asset1)),  400);
+
+        _assertInvariants();
     }
 
 }

--- a/test/arranger-conduit/Deposit.t.sol
+++ b/test/arranger-conduit/Deposit.t.sol
@@ -12,6 +12,7 @@ contract ArrangerConduit_DepositFailureTests is ConduitAssetTestBase {
         conduit.deposit(ilk1, address(asset1), 100);
     }
 
+    // NOTE: This test doesn't apply really in practice because of buffer setup, but being thorough
     function test_deposit_insufficientApproveBoundary() public {
         asset1.mint(buffer1, 100);
 
@@ -29,6 +30,7 @@ contract ArrangerConduit_DepositFailureTests is ConduitAssetTestBase {
         conduit.deposit(ilk1, address(asset1), 100);
     }
 
+    // NOTE: This test doesn't apply really in practice because of buffer setup, but being thorough
     function testFuzz_deposit_insufficientApproveBoundary(uint256 amount) public {
         vm.assume(amount != 0);
 

--- a/test/arranger-conduit/Deposit.t.sol
+++ b/test/arranger-conduit/Deposit.t.sol
@@ -79,22 +79,22 @@ contract ArrangerConduit_DepositFailureTests is ConduitAssetTestBase {
     }
 
     function test_deposit_noBufferRegistered() external {
-        asset.mint(operator, 100);
+        asset1.mint(operator1, 100);
 
-        registry.file(ilk, "buffer", address(0));
+        registry.file(ilk1, "buffer", address(0));
 
-        vm.startPrank(operator);
-        asset.approve(address(conduit), 100);
+        vm.startPrank(operator1);
+        asset1.approve(address(conduit), 100);
 
         vm.expectRevert("ArrangerConduit/no-buffer-registered");
-        conduit.deposit(ilk, address(asset), 100);
+        conduit.deposit(ilk1, address(asset1), 100);
 
         vm.stopPrank();
 
-        registry.file(ilk, "buffer", operator);
+        registry.file(ilk1, "buffer", operator1);
 
-        vm.prank(operator);
-        conduit.deposit(ilk, address(asset), 100);
+        vm.prank(operator1);
+        conduit.deposit(ilk1, address(asset1), 100);
     }
 
 }

--- a/test/arranger-conduit/DrawFunds.t.sol
+++ b/test/arranger-conduit/DrawFunds.t.sol
@@ -26,8 +26,9 @@ contract ArrangerConduit_DrawFundsTests is ConduitAssetTestBase {
     function test_drawFunds_invalidBroker() external {
         vm.startPrank(arranger);
 
+        // NOTE: `broker2` was not configured in setup for `asset1`
         vm.expectRevert("ArrangerConduit/invalid-broker");
-        conduit.drawFunds(address(asset1), makeAddr("non-broker1"), 100);
+        conduit.drawFunds(address(asset1), broker2, 100);
     }
 
     function test_drawFunds_insufficientDrawableBoundary() external {

--- a/test/arranger-conduit/DrawFunds.t.sol
+++ b/test/arranger-conduit/DrawFunds.t.sol
@@ -8,53 +8,53 @@ contract ArrangerConduit_DrawFundsTests is ConduitAssetTestBase {
     function setUp() public virtual override {
         super.setUp();
 
-        asset.mint(operator, 100);
+        asset1.mint(buffer1, 100);
 
-        vm.startPrank(operator);
+        vm.startPrank(operator1);
 
-        asset.approve(address(conduit), 100);
-        conduit.deposit(ilk, address(asset), 100);
+        asset1.approve(address(conduit), 100);
+        conduit.deposit(ilk1, address(asset1), 100);
 
         vm.stopPrank();
     }
 
     function test_drawFunds_notArranger() external {
         vm.expectRevert("ArrangerConduit/not-arranger");
-        conduit.drawFunds(address(asset), broker, 100);
+        conduit.drawFunds(address(asset1), broker1, 100);
     }
 
     function test_drawFunds_invalidBroker() external {
         vm.startPrank(arranger);
 
         vm.expectRevert("ArrangerConduit/invalid-broker");
-        conduit.drawFunds(address(asset), makeAddr("non-broker"), 100);
+        conduit.drawFunds(address(asset1), makeAddr("non-broker1"), 100);
     }
 
     function test_drawFunds_insufficientDrawableBoundary() external {
-        assertEq(conduit.availableFunds(address(asset)), 100);
+        assertEq(conduit.availableFunds(address(asset1)), 100);
 
         vm.startPrank(arranger);
 
         vm.expectRevert("ArrangerConduit/insufficient-funds");
-        conduit.drawFunds(address(asset), broker, 101);
+        conduit.drawFunds(address(asset1), broker1, 101);
 
-        conduit.drawFunds(address(asset), broker, 100);
+        conduit.drawFunds(address(asset1), broker1, 100);
     }
 
     function test_drawFunds() public {
-        assertEq(conduit.availableFunds(address(asset)), 100);
+        assertEq(conduit.availableFunds(address(asset1)), 100);
 
-        assertEq(asset.balanceOf(address(conduit)), 100);
-        assertEq(asset.balanceOf(broker),           0);
+        assertEq(asset1.balanceOf(address(conduit)), 100);
+        assertEq(asset1.balanceOf(broker1),          0);
 
         vm.prank(arranger);
-        conduit.drawFunds(address(asset), broker, 40);
+        conduit.drawFunds(address(asset1), broker1, 40);
 
-        assertEq(conduit.availableFunds(address(asset)), 60);
+        assertEq(conduit.availableFunds(address(asset1)), 60);
 
-        assertEq(asset.balanceOf(address(conduit)), 60);
-        assertEq(asset.balanceOf(broker),           40);
+        assertEq(asset1.balanceOf(address(conduit)), 60);
+        assertEq(asset1.balanceOf(broker1),          40);
 
-        _assertInvariants(ilk, address(asset));
+        _assertInvariants();
     }
 }

--- a/test/arranger-conduit/EventsData.t.sol
+++ b/test/arranger-conduit/EventsData.t.sol
@@ -6,23 +6,23 @@ import "./ConduitTestBase.sol";
 contract ArrangerConduit_EventTests is ConduitAssetTestBase {
 
     event CancelFundRequest(uint256 fundRequestId);
-    event Deposit(bytes32 indexed ilk1, address indexed asset, address origin, uint256 amount);
+    event Deposit(bytes32 indexed ilk, address indexed asset, address origin, uint256 amount);
     event DrawFunds(address indexed asset, address indexed destination, uint256 amount);
     event RequestFunds(
-        bytes32 indexed ilk1,
+        bytes32 indexed ilk,
         address indexed asset,
         uint256 fundRequestId,
         uint256 amount,
         string  info
     );
     event ReturnFunds(
-        bytes32 indexed ilk1,
+        bytes32 indexed ilk,
         address indexed asset,
         uint256 fundRequestId,
         uint256 amountRequested,
         uint256 returnAmount
     );
-    event Withdraw(bytes32 indexed ilk1, address indexed asset, address destination, uint256 amount);
+    event Withdraw(bytes32 indexed ilk, address indexed asset, address destination, uint256 amount);
 
     function test_cancelFundRequest() public {
         asset1.mint(buffer1, 200);

--- a/test/arranger-conduit/EventsData.t.sol
+++ b/test/arranger-conduit/EventsData.t.sol
@@ -3,41 +3,40 @@ pragma solidity ^0.8.13;
 
 import "./ConduitTestBase.sol";
 
-contract ArrangerConduit_WithdrawTests is ConduitAssetTestBase {
+contract ArrangerConduit_EventTests is ConduitAssetTestBase {
 
     event CancelFundRequest(uint256 fundRequestId);
-    event Deposit(bytes32 indexed ilk, address indexed asset, address origin, uint256 amount);
+    event Deposit(bytes32 indexed ilk1, address indexed asset, address origin, uint256 amount);
     event DrawFunds(address indexed asset, address indexed destination, uint256 amount);
     event RequestFunds(
-        bytes32 indexed ilk,
+        bytes32 indexed ilk1,
         address indexed asset,
         uint256 fundRequestId,
         uint256 amount,
         string  info
     );
     event ReturnFunds(
-        bytes32 indexed ilk,
+        bytes32 indexed ilk1,
         address indexed asset,
         uint256 fundRequestId,
         uint256 amountRequested,
         uint256 returnAmount
     );
-    event Withdraw(bytes32 indexed ilk, address indexed asset, address destination, uint256 amount);
+    event Withdraw(bytes32 indexed ilk1, address indexed asset, address destination, uint256 amount);
 
     function test_cancelFundRequest() public {
-        asset.mint(operator, 200);
+        asset1.mint(buffer1, 200);
 
-        vm.startPrank(operator);
+        vm.startPrank(operator1);
 
-        asset.approve(address(conduit), 100);
-        conduit.deposit(ilk, address(asset), 100);
-        conduit.requestFunds(ilk, address(asset), 100, "info");
+        conduit.deposit(ilk1, address(asset1), 100);
+        conduit.requestFunds(ilk1, address(asset1), 100, "info");
 
         vm.expectEmit(address(conduit));
         emit CancelFundRequest(0);
         conduit.cancelFundRequest(0);
 
-        conduit.requestFunds(ilk, address(asset), 100, "info");
+        conduit.requestFunds(ilk1, address(asset1), 100, "info");
 
         // Ensure incrementing
         vm.expectEmit(address(conduit));
@@ -46,31 +45,24 @@ contract ArrangerConduit_WithdrawTests is ConduitAssetTestBase {
     }
 
     function test_deposit() external {
-        asset.mint(operator, 100);
+        asset1.mint(buffer1, 100);
 
-        vm.startPrank(operator);
-
-        asset.approve(address(conduit), 100);
-
+        vm.prank(operator1);
         vm.expectEmit(address(conduit));
-        emit Deposit(ilk, address(asset), operator, 100);
-        conduit.deposit(ilk, address(asset), 100);
+        emit Deposit(ilk1, address(asset1), buffer1, 100);
+        conduit.deposit(ilk1, address(asset1), 100);
     }
 
     function test_drawFunds() public {
-        asset.mint(operator, 100);
+        asset1.mint(buffer1, 100);
 
-        vm.startPrank(operator);
-
-        asset.approve(address(conduit), 100);
-        conduit.deposit(ilk, address(asset), 100);
-
-        vm.stopPrank();
+        vm.prank(operator1);
+        conduit.deposit(ilk1, address(asset1), 100);
 
         vm.prank(arranger);
         vm.expectEmit(address(conduit));
-        emit DrawFunds(address(asset), broker, 40);
-        conduit.drawFunds(address(asset), broker, 40);
+        emit DrawFunds(address(asset1), broker1, 40);
+        conduit.drawFunds(address(asset1), broker1, 40);
     }
 
     function test_file() public {
@@ -80,79 +72,74 @@ contract ArrangerConduit_WithdrawTests is ConduitAssetTestBase {
     }
 
     function test_requestFunds() public {
-        asset.mint(operator, 100);
+        asset1.mint(buffer1, 100);
 
-        vm.startPrank(operator);
+        vm.startPrank(operator1);
 
-        asset.approve(address(conduit), 100);
-        conduit.deposit(ilk, address(asset), 100);
+        conduit.deposit(ilk1, address(asset1), 100);
 
         vm.expectEmit(address(conduit));
-        emit RequestFunds(ilk, address(asset), 0, 100, "info");
-        conduit.requestFunds(ilk, address(asset), 100, "info");
+        emit RequestFunds(ilk1, address(asset1), 0, 100, "info");
+        conduit.requestFunds(ilk1, address(asset1), 100, "info");
 
         // Assert id increments
         vm.expectEmit(address(conduit));
-        emit RequestFunds(ilk, address(asset), 1, 50, "info");
-        conduit.requestFunds(ilk, address(asset), 50, "info");
+        emit RequestFunds(ilk1, address(asset1), 1, 50, "info");
+        conduit.requestFunds(ilk1, address(asset1), 50, "info");
     }
 
     function test_returnFunds() external {
-        asset.mint(operator, 100);
+        asset1.mint(buffer1, 100);
 
-        vm.startPrank(operator);
-
-        asset.approve(address(conduit), 100);
-        conduit.deposit(ilk, address(asset), 100);
-
-        vm.stopPrank();
+        vm.prank(operator1);
+        conduit.deposit(ilk1, address(asset1), 100);
 
         vm.prank(arranger);
-        conduit.drawFunds(address(asset), broker, 100);
+        conduit.drawFunds(address(asset1), broker1, 100);
 
-        asset.mint(address(conduit), 100);
+        asset1.mint(address(conduit), 100);
 
-        vm.prank(operator);
-        conduit.requestFunds(ilk, address(asset), 20, "info");
+        vm.prank(operator1);
+        conduit.requestFunds(ilk1, address(asset1), 20, "info");
 
         vm.startPrank(arranger);
 
-        asset.approve(address(conduit), 30);
+        asset1.approve(address(conduit), 30);
 
         // Request 20, return 30
         vm.expectEmit(address(conduit));
-        emit ReturnFunds(ilk, address(asset), 0, 20, 30);
+        emit ReturnFunds(ilk1, address(asset1), 0, 20, 30);
         conduit.returnFunds(0, 30);
 
         vm.stopPrank();
 
-        vm.prank(operator);
-        conduit.requestFunds(ilk, address(asset), 50, "info");
+        vm.prank(operator1);
+        conduit.requestFunds(ilk1, address(asset1), 50, "info");
 
         vm.startPrank(arranger);
-        asset.approve(address(conduit), 40);
+        asset1.approve(address(conduit), 40);
 
         // Request 50, return 40, assert id increments
         vm.expectEmit(address(conduit));
-        emit ReturnFunds(ilk, address(asset), 1, 50, 40);
+        emit ReturnFunds(ilk1, address(asset1), 1, 50, 40);
         conduit.returnFunds(1, 40);
     }
 
     function test_withdraw() external {
-        _depositAndDrawFunds(asset, operator, ilk, 100);
+        _depositAndDrawFunds(100);
 
-        vm.prank(operator);
-        conduit.requestFunds(ilk, address(asset), 100, "info");
+        vm.prank(operator1);
+        conduit.requestFunds(ilk1, address(asset1), 100, "info");
 
-        asset.mint(address(conduit), 100);
+        asset1.mint(address(conduit), 100);
 
         vm.prank(arranger);
         conduit.returnFunds(0, 100);
 
-        vm.prank(operator);
+        vm.prank(operator1);
         vm.expectEmit(address(conduit));
-        emit Withdraw(ilk, address(asset), operator, 100);
-        conduit.withdraw(ilk, address(asset), 100);
+        emit Withdraw(ilk1, address(asset1), buffer1, 100);
+        conduit.withdraw(ilk1, address(asset1), 100);
     }
 
 }

--- a/test/arranger-conduit/RequestFunds.t.sol
+++ b/test/arranger-conduit/RequestFunds.t.sol
@@ -8,82 +8,57 @@ import "./ConduitTestBase.sol";
 contract ArrangerConduit_RequestFundsTests is ConduitAssetTestBase {
 
     function test_requestFunds_noIlkAuth() public {
-        asset.mint(operator, 100);
+        asset1.mint(buffer1, 100);
 
-        vm.startPrank(operator);
-
-        asset.approve(address(conduit), 100);
-        conduit.deposit(ilk, address(asset), 100);
-
-        vm.stopPrank();
+        vm.prank(operator1);
+        conduit.deposit(ilk1, address(asset1), 100);
 
         vm.expectRevert("ArrangerConduit/not-authorized");
-        conduit.requestFunds(ilk, address(asset), 100, "info");
+        conduit.requestFunds(ilk1, address(asset1), 100, "info");
     }
 
     function test_requestFunds_singleIlk_singleRequest() public {
-        asset.mint(operator, 100);
+        asset1.mint(buffer1, 100);
 
-        vm.startPrank(operator);
+        vm.startPrank(operator1);
 
-        asset.approve(address(conduit), 100);
-        conduit.deposit(ilk, address(asset), 100);
+        conduit.deposit(ilk1, address(asset1), 100);
 
-        assertEq(conduit.requestedFunds(address(asset), ilk), 0);
+        assertEq(conduit.requestedFunds(address(asset1), ilk1), 0);
 
-        conduit.requestFunds(ilk, address(asset), 100, "info");
+        conduit.requestFunds(ilk1, address(asset1), 100, "info");
 
         IArrangerConduit.FundRequest memory fundRequest = conduit.getFundRequest(0);
 
         assertTrue(fundRequest.status == IArrangerConduit.StatusEnum.PENDING);
 
-        assertEq(fundRequest.asset,           address(asset));
-        assertEq(fundRequest.ilk,             ilk);
+        assertEq(fundRequest.asset,           address(asset1));
+        assertEq(fundRequest.ilk,             ilk1);
         assertEq(fundRequest.amountRequested, 100);
         assertEq(fundRequest.amountFilled,    0);
         assertEq(fundRequest.info,            "info");
 
-        assertEq(conduit.requestedFunds(address(asset), ilk), 100);
-        assertEq(conduit.totalRequestedFunds(address(asset)), 100);
+        assertEq(conduit.requestedFunds(address(asset1), ilk1), 100);
+        assertEq(conduit.totalRequestedFunds(address(asset1)),  100);
 
-        _assertInvariants(ilk, address(asset));
+        _assertInvariants();
     }
 
     function test_requestFunds_multiIlk_singleRequest_singleAsset() public {
-        bytes32 ilk1 = "ilk1";
-        bytes32 ilk2 = "ilk2";
-
-        address operator1 = makeAddr("operator1");
-        address operator2 = makeAddr("operator2");
-
-        _setupOperatorRole(ilk1, operator1);
-        _setupOperatorRole(ilk2, operator2);
-
-        registry.file(ilk1, "buffer", operator1);
-        registry.file(ilk2, "buffer", operator2);
-
-        asset.mint(operator1, 40);
-        asset.mint(operator2, 60);
-
-        vm.startPrank(operator1);
-
-        asset.approve(address(conduit), 40);
-        conduit.deposit(ilk1, address(asset), 40);
-
-        vm.stopPrank();
-
-        vm.startPrank(operator2);
-
-        asset.approve(address(conduit), 60);
-        conduit.deposit(ilk2, address(asset), 60);
-
-        vm.stopPrank();
-
-        assertEq(conduit.requestedFunds(address(asset), ilk1), 0);
-        assertEq(conduit.requestedFunds(address(asset), ilk2), 0);
+        asset1.mint(buffer1, 40);
+        asset1.mint(buffer2, 60);
 
         vm.prank(operator1);
-        uint256 returnFundRequestId = conduit.requestFunds(ilk1, address(asset), 40, "info1");
+        conduit.deposit(ilk1, address(asset1), 40);
+
+        vm.prank(operator2);
+        conduit.deposit(ilk2, address(asset1), 60);
+
+        assertEq(conduit.requestedFunds(address(asset1), ilk1), 0);
+        assertEq(conduit.requestedFunds(address(asset1), ilk2), 0);
+
+        vm.prank(operator1);
+        uint256 returnFundRequestId = conduit.requestFunds(ilk1, address(asset1), 40, "info1");
 
         assertEq(returnFundRequestId, 0);
 
@@ -91,17 +66,17 @@ contract ArrangerConduit_RequestFundsTests is ConduitAssetTestBase {
 
         assertTrue(fundRequest.status == IArrangerConduit.StatusEnum.PENDING);
 
-        assertEq(fundRequest.asset,           address(asset));
+        assertEq(fundRequest.asset,           address(asset1));
         assertEq(fundRequest.ilk,             ilk1);
         assertEq(fundRequest.amountRequested, 40);
         assertEq(fundRequest.amountFilled,    0);
         assertEq(fundRequest.info,            "info1");
 
-        assertEq(conduit.requestedFunds(address(asset), ilk1), 40);
-        assertEq(conduit.totalRequestedFunds(address(asset)),  40);
+        assertEq(conduit.requestedFunds(address(asset1), ilk1), 40);
+        assertEq(conduit.totalRequestedFunds(address(asset1)),  40);
 
         vm.prank(operator2);
-        returnFundRequestId = conduit.requestFunds(ilk2, address(asset), 60, "info2");
+        returnFundRequestId = conduit.requestFunds(ilk2, address(asset1), 60, "info2");
 
         assertEq(returnFundRequestId, 1);
 
@@ -109,117 +84,92 @@ contract ArrangerConduit_RequestFundsTests is ConduitAssetTestBase {
 
         assertTrue(fundRequest.status == IArrangerConduit.StatusEnum.PENDING);
 
-        assertEq(fundRequest.asset,           address(asset));
+        assertEq(fundRequest.asset,           address(asset1));
         assertEq(fundRequest.ilk,             ilk2);
         assertEq(fundRequest.amountRequested, 60);
         assertEq(fundRequest.amountFilled,    0);
         assertEq(fundRequest.info,            "info2");
 
-        assertEq(conduit.requestedFunds(address(asset), ilk2), 60);
-        assertEq(conduit.totalRequestedFunds(address(asset)),  100);
+        assertEq(conduit.requestedFunds(address(asset1), ilk2), 60);
+        assertEq(conduit.totalRequestedFunds(address(asset1)),  100);
 
-        _assertInvariants(ilk1, ilk2, address(asset));
+        _assertInvariants();
     }
 
     // NOTE: Removing all struct-level assertions for below tests since they have been adequately
     //       asserted in above tests and FundRequest structs are mutually exclusive to each other
     //       as proven in the above test. Below tests are only testing the mapping-level handling of
-    //       multi-ilk multi-asset scenarios.
+    //       multi-ilk1 multi-asset scenarios.
 
     function test_requestFunds_singleIlk_multiRequest_singleAsset() public {
-        asset.mint(operator, 100);
+        asset1.mint(buffer1, 100);
 
-        vm.startPrank(operator);
+        vm.startPrank(operator1);
 
-        asset.approve(address(conduit), 100);
-        conduit.deposit(ilk, address(asset), 100);
+        conduit.deposit(ilk1, address(asset1), 100);
 
-        assertEq(conduit.requestedFunds(address(asset), ilk), 0);
+        assertEq(conduit.requestedFunds(address(asset1), ilk1), 0);
 
-        uint256 returnFundRequestId = conduit.requestFunds(ilk, address(asset), 40, "info");
+        uint256 returnFundRequestId = conduit.requestFunds(ilk1, address(asset1), 40, "info");
 
         assertEq(returnFundRequestId, 0);
 
-        assertEq(conduit.requestedFunds(address(asset), ilk), 40);
-        assertEq(conduit.totalRequestedFunds(address(asset)), 40);
+        assertEq(conduit.requestedFunds(address(asset1), ilk1), 40);
+        assertEq(conduit.totalRequestedFunds(address(asset1)), 40);
 
-        returnFundRequestId = conduit.requestFunds(ilk, address(asset), 60, "info");
+        returnFundRequestId = conduit.requestFunds(ilk1, address(asset1), 60, "info");
 
-        assertEq(conduit.requestedFunds(address(asset), ilk), 100);
-        assertEq(conduit.totalRequestedFunds(address(asset)), 100);
+        assertEq(conduit.requestedFunds(address(asset1), ilk1), 100);
+        assertEq(conduit.totalRequestedFunds(address(asset1)), 100);
 
-        _assertInvariants(ilk, address(asset));
+        _assertInvariants();
     }
 
     function test_requestFunds_singleIlk_singleRequest_multiAsset() public {
-        MockERC20 asset1 = new MockERC20("asset1", "asset1", 18);
-        MockERC20 asset2 = new MockERC20("asset2", "asset2", 18);
+        asset1.mint(buffer1, 100);
+        asset2.mint(buffer1, 300);
 
-        asset1.mint(operator, 100);
-        asset2.mint(operator, 300);
+        vm.startPrank(operator1);
 
-        vm.startPrank(operator);
+        conduit.deposit(ilk1, address(asset1), 100);
+        conduit.deposit(ilk1, address(asset2), 300);
 
-        asset1.approve(address(conduit), 100);
-        asset2.approve(address(conduit), 300);
+        assertEq(conduit.requestedFunds(address(asset1), ilk1), 0);
+        assertEq(conduit.requestedFunds(address(asset2), ilk1), 0);
 
-        conduit.deposit(ilk, address(asset1), 100);
-        conduit.deposit(ilk, address(asset2), 300);
-
-        assertEq(conduit.requestedFunds(address(asset1), ilk), 0);
-        assertEq(conduit.requestedFunds(address(asset2), ilk), 0);
-
-        uint256 returnFundRequestId = conduit.requestFunds(ilk, address(asset1), 100, "info1");
+        uint256 returnFundRequestId = conduit.requestFunds(ilk1, address(asset1), 100, "info1");
 
         assertEq(returnFundRequestId, 0);
 
-        assertEq(conduit.requestedFunds(address(asset1), ilk), 100);
-        assertEq(conduit.requestedFunds(address(asset2), ilk), 0);
-        assertEq(conduit.totalRequestedFunds(address(asset1)), 100);
-        assertEq(conduit.totalRequestedFunds(address(asset2)), 0);
+        assertEq(conduit.requestedFunds(address(asset1), ilk1), 100);
+        assertEq(conduit.requestedFunds(address(asset2), ilk1), 0);
+        assertEq(conduit.totalRequestedFunds(address(asset1)),  100);
+        assertEq(conduit.totalRequestedFunds(address(asset2)),  0);
 
-        returnFundRequestId = conduit.requestFunds(ilk, address(asset2), 300, "info2");
+        returnFundRequestId = conduit.requestFunds(ilk1, address(asset2), 300, "info2");
 
         assertEq(returnFundRequestId, 1);
 
-        assertEq(conduit.requestedFunds(address(asset1), ilk), 100);
-        assertEq(conduit.requestedFunds(address(asset2), ilk), 300);
-        assertEq(conduit.totalRequestedFunds(address(asset1)), 100);
-        assertEq(conduit.totalRequestedFunds(address(asset2)), 300);
+        assertEq(conduit.requestedFunds(address(asset1), ilk1), 100);
+        assertEq(conduit.requestedFunds(address(asset2), ilk1), 300);
+        assertEq(conduit.totalRequestedFunds(address(asset1)),  100);
+        assertEq(conduit.totalRequestedFunds(address(asset2)),  300);
 
-        _assertInvariants(ilk, address(asset1));
-        _assertInvariants(ilk, address(asset2));
+        _assertInvariants();
     }
 
     function test_requestFunds_multiIlk_multiRequest_multiAsset() public {
-        MockERC20 asset1 = new MockERC20("asset1", "asset1", 18);
-        MockERC20 asset2 = new MockERC20("asset2", "asset2", 18);
-
-        bytes32 ilk1 = "ilk1";
-        bytes32 ilk2 = "ilk2";
-
-        address operator1 = makeAddr("operator1");
-        address operator2 = makeAddr("operator2");
-
-        _setupOperatorRole(ilk1, operator1);
-        _setupOperatorRole(ilk2, operator2);
-
-        registry.file(ilk1, "buffer", operator1);
-        registry.file(ilk2, "buffer", operator2);
 
         /********************************************/
         /*** First round of deposits and requests ***/
         /********************************************/
 
-        asset1.mint(operator1, 40);
-        asset1.mint(operator2, 60);
-        asset2.mint(operator1, 100);
-        asset2.mint(operator2, 300);
+        asset1.mint(buffer1, 40);
+        asset1.mint(buffer2, 60);
+        asset2.mint(buffer1, 100);
+        asset2.mint(buffer2, 300);
 
         vm.startPrank(operator1);
-
-        asset1.approve(address(conduit), 40);
-        asset2.approve(address(conduit), 100);
 
         conduit.deposit(ilk1, address(asset1), 40);
         conduit.deposit(ilk1, address(asset2), 100);
@@ -227,9 +177,6 @@ contract ArrangerConduit_RequestFundsTests is ConduitAssetTestBase {
         vm.stopPrank();
 
         vm.startPrank(operator2);
-
-        asset1.approve(address(conduit), 60);
-        asset2.approve(address(conduit), 300);
 
         conduit.deposit(ilk2, address(asset1), 60);
         conduit.deposit(ilk2, address(asset2), 300);
@@ -244,8 +191,7 @@ contract ArrangerConduit_RequestFundsTests is ConduitAssetTestBase {
         assertEq(conduit.totalRequestedFunds(address(asset1)), 0);
         assertEq(conduit.totalRequestedFunds(address(asset2)), 0);
 
-        _assertInvariants(ilk1, ilk2, address(asset1));
-        _assertInvariants(ilk1, ilk2, address(asset2));
+        _assertInvariants();
 
         // Request Funds for asset1 ilk1
 
@@ -262,8 +208,7 @@ contract ArrangerConduit_RequestFundsTests is ConduitAssetTestBase {
         assertEq(conduit.totalRequestedFunds(address(asset1)), 40);
         assertEq(conduit.totalRequestedFunds(address(asset2)), 0);
 
-        _assertInvariants(ilk1, ilk2, address(asset1));
-        _assertInvariants(ilk1, ilk2, address(asset2));
+        _assertInvariants();
 
         // Request Funds for asset1 ilk2
 
@@ -280,8 +225,7 @@ contract ArrangerConduit_RequestFundsTests is ConduitAssetTestBase {
         assertEq(conduit.totalRequestedFunds(address(asset1)), 100);
         assertEq(conduit.totalRequestedFunds(address(asset2)), 0);
 
-        _assertInvariants(ilk1, ilk2, address(asset1));
-        _assertInvariants(ilk1, ilk2, address(asset2));
+        _assertInvariants();
 
         // Request Funds for asset2 ilk1
 
@@ -298,8 +242,7 @@ contract ArrangerConduit_RequestFundsTests is ConduitAssetTestBase {
         assertEq(conduit.totalRequestedFunds(address(asset1)), 100);
         assertEq(conduit.totalRequestedFunds(address(asset2)), 100);
 
-        _assertInvariants(ilk1, ilk2, address(asset1));
-        _assertInvariants(ilk1, ilk2, address(asset2));
+        _assertInvariants();
 
         // Request Funds for asset2 ilk2
 
@@ -316,32 +259,23 @@ contract ArrangerConduit_RequestFundsTests is ConduitAssetTestBase {
         assertEq(conduit.totalRequestedFunds(address(asset1)), 100);
         assertEq(conduit.totalRequestedFunds(address(asset2)), 400);
 
-        _assertInvariants(ilk1, ilk2, address(asset1));
-        _assertInvariants(ilk1, ilk2, address(asset2));
+        _assertInvariants();
 
         /*********************************************/
         /*** Second round of deposits and requests ***/
         /*********************************************/
 
-        asset1.mint(operator1, 40);
-        asset1.mint(operator2, 60);
-        asset2.mint(operator1, 100);
-        asset2.mint(operator2, 300);
+        asset1.mint(buffer1, 40);
+        asset1.mint(buffer2, 60);
+        asset2.mint(buffer1, 100);
+        asset2.mint(buffer2, 300);
 
         vm.startPrank(operator1);
-
-        asset1.approve(address(conduit), 40);
-        asset2.approve(address(conduit), 100);
 
         conduit.deposit(ilk1, address(asset1), 40);
         conduit.deposit(ilk1, address(asset2), 100);
 
-        vm.stopPrank();
-
         vm.startPrank(operator2);
-
-        asset1.approve(address(conduit), 60);
-        asset2.approve(address(conduit), 300);
 
         conduit.deposit(ilk2, address(asset1), 60);
         conduit.deposit(ilk2, address(asset2), 300);
@@ -363,8 +297,7 @@ contract ArrangerConduit_RequestFundsTests is ConduitAssetTestBase {
         assertEq(conduit.totalRequestedFunds(address(asset1)), 140);
         assertEq(conduit.totalRequestedFunds(address(asset2)), 400);
 
-        _assertInvariants(ilk1, ilk2, address(asset1));
-        _assertInvariants(ilk1, ilk2, address(asset2));
+        _assertInvariants();
 
         // Request Funds for asset1 ilk2
 
@@ -381,8 +314,7 @@ contract ArrangerConduit_RequestFundsTests is ConduitAssetTestBase {
         assertEq(conduit.totalRequestedFunds(address(asset1)), 200);
         assertEq(conduit.totalRequestedFunds(address(asset2)), 400);
 
-        _assertInvariants(ilk1, ilk2, address(asset1));
-        _assertInvariants(ilk1, ilk2, address(asset2));
+        _assertInvariants();
 
         // Request Funds for asset2 ilk1
 
@@ -399,8 +331,7 @@ contract ArrangerConduit_RequestFundsTests is ConduitAssetTestBase {
         assertEq(conduit.totalRequestedFunds(address(asset1)), 200);
         assertEq(conduit.totalRequestedFunds(address(asset2)), 500);
 
-        _assertInvariants(ilk1, ilk2, address(asset1));
-        _assertInvariants(ilk1, ilk2, address(asset2));
+        _assertInvariants();
 
         // Request Funds for asset2 ilk2
 
@@ -417,8 +348,7 @@ contract ArrangerConduit_RequestFundsTests is ConduitAssetTestBase {
         assertEq(conduit.totalRequestedFunds(address(asset1)), 200);
         assertEq(conduit.totalRequestedFunds(address(asset2)), 800);
 
-        _assertInvariants(ilk1, ilk2, address(asset1));
-        _assertInvariants(ilk1, ilk2, address(asset2));
+        _assertInvariants();
     }
 
 }

--- a/test/arranger-conduit/RequestFunds.t.sol
+++ b/test/arranger-conduit/RequestFunds.t.sol
@@ -99,7 +99,7 @@ contract ArrangerConduit_RequestFundsTests is ConduitAssetTestBase {
     // NOTE: Removing all struct-level assertions for below tests since they have been adequately
     //       asserted in above tests and FundRequest structs are mutually exclusive to each other
     //       as proven in the above test. Below tests are only testing the mapping-level handling of
-    //       multi-ilk1 multi-asset scenarios.
+    //       multi-ilk multi-asset scenarios.
 
     function test_requestFunds_singleIlk_multiRequest_singleAsset() public {
         asset1.mint(buffer1, 100);
@@ -115,12 +115,12 @@ contract ArrangerConduit_RequestFundsTests is ConduitAssetTestBase {
         assertEq(returnFundRequestId, 0);
 
         assertEq(conduit.requestedFunds(address(asset1), ilk1), 40);
-        assertEq(conduit.totalRequestedFunds(address(asset1)), 40);
+        assertEq(conduit.totalRequestedFunds(address(asset1)),  40);
 
         returnFundRequestId = conduit.requestFunds(ilk1, address(asset1), 60, "info");
 
         assertEq(conduit.requestedFunds(address(asset1), ilk1), 100);
-        assertEq(conduit.totalRequestedFunds(address(asset1)), 100);
+        assertEq(conduit.totalRequestedFunds(address(asset1)),  100);
 
         _assertInvariants();
     }

--- a/test/arranger-conduit/Withdraw.t.sol
+++ b/test/arranger-conduit/Withdraw.t.sol
@@ -20,26 +20,26 @@ contract ArrangerConduit_WithdrawTests is ConduitAssetTestBase {
     }
 
     function test_withdraw_noBufferRegistered() external {
-        _depositAndDrawFunds(asset, operator, ilk, 100);
+        _depositAndDrawFunds(100);
 
-        vm.prank(operator);
-        conduit.requestFunds(ilk, address(asset), 100, "info");
+        vm.prank(operator1);
+        conduit.requestFunds(ilk1, address(asset1), 100, "info");
 
-        asset.mint(address(conduit), 100);
+        asset1.mint(address(conduit), 100);
 
         vm.prank(arranger);
         conduit.returnFunds(0, 100);
 
-        registry.file(ilk, "buffer", address(0));
+        registry.file(ilk1, "buffer", address(0));
 
-        vm.prank(operator);
+        vm.prank(operator1);
         vm.expectRevert("ArrangerConduit/no-buffer-registered");
-        conduit.withdraw(ilk, address(asset), 100);
+        conduit.withdraw(ilk1, address(asset1), 100);
 
-        registry.file(ilk, "buffer", operator);
+        registry.file(ilk1, "buffer", operator1);
 
-        vm.prank(operator);
-        conduit.withdraw(ilk, address(asset), 100);
+        vm.prank(operator1);
+        conduit.withdraw(ilk1, address(asset1), 100);
     }
 
     function test_withdraw_moreThanWithdrawable() external {

--- a/test/arranger-conduit/Withdraw.t.sol
+++ b/test/arranger-conduit/Withdraw.t.sol
@@ -6,111 +6,98 @@ import "./ConduitTestBase.sol";
 contract ArrangerConduit_WithdrawTests is ConduitAssetTestBase {
 
     function test_withdraw_noIlkAuth() external {
-        asset.mint(operator, 100);
+        asset1.mint(buffer1, 100);
 
-        vm.startPrank(operator);
+        vm.startPrank(operator1);
 
-        asset.approve(address(conduit), 100);
-        conduit.deposit(ilk, address(asset), 100);
-        conduit.requestFunds(ilk, address(asset), 100, "info");
+        conduit.deposit(ilk1, address(asset1), 100);
+        conduit.requestFunds(ilk1, address(asset1), 100, "info");
 
         vm.stopPrank();
 
         vm.expectRevert("ArrangerConduit/not-authorized");
-        conduit.withdraw(ilk, address(asset), 100);
+        conduit.withdraw(ilk1, address(asset1), 100);
     }
 
     function test_withdraw_moreThanWithdrawable() external {
-        _depositAndDrawFunds(asset, operator, ilk, 100);
+        _depositAndDrawFunds(100);
 
-        vm.prank(operator);
-        conduit.requestFunds(ilk, address(asset), 100, "info");
+        vm.prank(operator1);
+        conduit.requestFunds(ilk1, address(asset1), 100, "info");
 
-        asset.mint(address(conduit), 100);
+        asset1.mint(address(conduit), 100);
 
         vm.prank(arranger);
         conduit.returnFunds(0, 100);
 
-        assertEq(asset.balanceOf(address(conduit)), 100);
-        assertEq(asset.balanceOf(operator),         0);
+        assertEq(asset1.balanceOf(address(conduit)), 100);
+        assertEq(asset1.balanceOf(buffer1),          0);
 
-        assertEq(conduit.withdrawableFunds(address(asset), ilk), 100);
-        assertEq(conduit.totalWithdrawableFunds(address(asset)), 100);
-        assertEq(conduit.withdrawals(address(asset), ilk),       0);
-        assertEq(conduit.totalWithdrawals(address(asset)),       0);
+        assertEq(conduit.withdrawableFunds(address(asset1), ilk1), 100);
+        assertEq(conduit.totalWithdrawableFunds(address(asset1)),  100);
+        assertEq(conduit.withdrawals(address(asset1), ilk1),       0);
+        assertEq(conduit.totalWithdrawals(address(asset1)),        0);
 
         // Try to withdraw 200 when only 100 is available
         // (using instead of 101 to show its not because of rounding)
-        vm.prank(operator);
-        uint256 amount = conduit.withdraw(ilk, address(asset), 200);
+        vm.prank(operator1);
+        uint256 amount = conduit.withdraw(ilk1, address(asset1), 200);
 
         assertEq(amount, 100);  // Receive max, which is 100
 
-        assertEq(asset.balanceOf(address(conduit)), 0);
-        assertEq(asset.balanceOf(operator),         100);
+        assertEq(asset1.balanceOf(address(conduit)), 0);
+        assertEq(asset1.balanceOf(buffer1),          100);
 
-        assertEq(conduit.withdrawableFunds(address(asset), ilk), 0);
-        assertEq(conduit.totalWithdrawableFunds(address(asset)), 0);
-        assertEq(conduit.withdrawals(address(asset), ilk),       100);
-        assertEq(conduit.totalWithdrawals(address(asset)),       100);
+        assertEq(conduit.withdrawableFunds(address(asset1), ilk1), 0);
+        assertEq(conduit.totalWithdrawableFunds(address(asset1)),  0);
+        assertEq(conduit.withdrawals(address(asset1), ilk1),       100);
+        assertEq(conduit.totalWithdrawals(address(asset1)),        100);
     }
 
     function test_withdraw_singleIlk() external {
-        _depositAndDrawFunds(asset, operator, ilk, 100);
+        _depositAndDrawFunds(100);
 
-        vm.prank(operator);
-        conduit.requestFunds(ilk, address(asset), 100, "info");
+        vm.prank(operator1);
+        conduit.requestFunds(ilk1, address(asset1), 100, "info");
 
-        asset.mint(address(conduit), 100);
+        asset1.mint(address(conduit), 100);
 
         vm.prank(arranger);
         conduit.returnFunds(0, 100);
 
-        assertEq(asset.balanceOf(address(conduit)), 100);
-        assertEq(asset.balanceOf(operator),         0);
+        assertEq(asset1.balanceOf(address(conduit)), 100);
+        assertEq(asset1.balanceOf(buffer1),          0);
 
-        assertEq(conduit.withdrawableFunds(address(asset), ilk), 100);
-        assertEq(conduit.totalWithdrawableFunds(address(asset)), 100);
-        assertEq(conduit.withdrawals(address(asset), ilk),       0);
-        assertEq(conduit.totalWithdrawals(address(asset)),       0);
+        assertEq(conduit.withdrawableFunds(address(asset1), ilk1), 100);
+        assertEq(conduit.totalWithdrawableFunds(address(asset1)),  100);
+        assertEq(conduit.withdrawals(address(asset1), ilk1),       0);
+        assertEq(conduit.totalWithdrawals(address(asset1)),        0);
 
-        vm.prank(operator);
-        uint256 amount = conduit.withdraw(ilk, address(asset), 100);
+        vm.prank(operator1);
+        uint256 amount = conduit.withdraw(ilk1, address(asset1), 100);
 
         assertEq(amount, 100);
 
-        assertEq(asset.balanceOf(address(conduit)), 0);
-        assertEq(asset.balanceOf(operator),         100);
+        assertEq(asset1.balanceOf(address(conduit)), 0);
+        assertEq(asset1.balanceOf(buffer1),          100);
 
-        assertEq(conduit.withdrawableFunds(address(asset), ilk), 0);
-        assertEq(conduit.totalWithdrawableFunds(address(asset)), 0);
-        assertEq(conduit.withdrawals(address(asset), ilk),       100);
-        assertEq(conduit.totalWithdrawals(address(asset)),       100);
+        assertEq(conduit.withdrawableFunds(address(asset1), ilk1), 0);
+        assertEq(conduit.totalWithdrawableFunds(address(asset1)),  0);
+        assertEq(conduit.withdrawals(address(asset1), ilk1),       100);
+        assertEq(conduit.totalWithdrawals(address(asset1)),        100);
     }
 
     function test_withdraw_multiIlk_over_under_partial_full_full() external {
-        bytes32 ilk1 = "ilk1";
-        bytes32 ilk2 = "ilk2";
-
-        address operator1 = makeAddr("operator1");
-        address operator2 = makeAddr("operator2");
-
-        _setupOperatorRole(ilk1, operator1);
-        _setupOperatorRole(ilk2, operator2);
-
-        registry.file(ilk1, "buffer", operator1);
-        registry.file(ilk2, "buffer", operator2);
-
-        _depositAndDrawFunds(asset, operator1, ilk1, 100);
-        _depositAndDrawFunds(asset, operator2, ilk2, 400);
+        _depositAndDrawFunds(100);
+        _depositAndDrawFunds(asset1, operator2, buffer2, broker1, ilk2, 400);
 
         vm.prank(operator1);
-        conduit.requestFunds(ilk1, address(asset), 100, "info");
+        conduit.requestFunds(ilk1, address(asset1), 100, "info");
 
         vm.prank(operator2);
-        conduit.requestFunds(ilk2, address(asset), 400, "info");
+        conduit.requestFunds(ilk2, address(asset1), 400, "info");
 
-        asset.mint(address(conduit), 500);
+        asset1.mint(address(conduit), 500);
 
         vm.startPrank(arranger);
 
@@ -119,70 +106,70 @@ contract ArrangerConduit_WithdrawTests is ConduitAssetTestBase {
 
         vm.stopPrank();
 
-        assertEq(asset.balanceOf(address(conduit)), 500);
-        assertEq(asset.balanceOf(operator1),        0);
-        assertEq(asset.balanceOf(operator2),        0);
+        assertEq(asset1.balanceOf(address(conduit)), 500);
+        assertEq(asset1.balanceOf(buffer1),          0);
+        assertEq(asset1.balanceOf(buffer2),          0);
 
-        assertEq(conduit.withdrawableFunds(address(asset), ilk1), 200);
-        assertEq(conduit.withdrawableFunds(address(asset), ilk2), 300);
-        assertEq(conduit.totalWithdrawableFunds(address(asset)),  500);
-        assertEq(conduit.withdrawals(address(asset), ilk1),       0);
-        assertEq(conduit.withdrawals(address(asset), ilk2),       0);
-        assertEq(conduit.totalWithdrawals(address(asset)),        0);
+        assertEq(conduit.withdrawableFunds(address(asset1), ilk1), 200);
+        assertEq(conduit.withdrawableFunds(address(asset1), ilk2), 300);
+        assertEq(conduit.totalWithdrawableFunds(address(asset1)),  500);
+        assertEq(conduit.withdrawals(address(asset1), ilk1),       0);
+        assertEq(conduit.withdrawals(address(asset1), ilk2),       0);
+        assertEq(conduit.totalWithdrawals(address(asset1)),        0);
 
-        // Partial withdraw ilk 1
+        // Partial withdraw ilk1 1
 
         vm.prank(operator1);
-        uint256 amount = conduit.withdraw(ilk1, address(asset), 50);
+        uint256 amount = conduit.withdraw(ilk1, address(asset1), 50);
 
         assertEq(amount, 50);
 
-        assertEq(asset.balanceOf(address(conduit)), 450);
-        assertEq(asset.balanceOf(operator1),        50);
-        assertEq(asset.balanceOf(operator2),        0);
+        assertEq(asset1.balanceOf(address(conduit)), 450);
+        assertEq(asset1.balanceOf(buffer1),          50);
+        assertEq(asset1.balanceOf(buffer2),          0);
 
-        assertEq(conduit.withdrawableFunds(address(asset), ilk1), 150);
-        assertEq(conduit.withdrawableFunds(address(asset), ilk2), 300);
-        assertEq(conduit.totalWithdrawableFunds(address(asset)),  450);
-        assertEq(conduit.withdrawals(address(asset), ilk1),       50);
-        assertEq(conduit.withdrawals(address(asset), ilk2),       0);
-        assertEq(conduit.totalWithdrawals(address(asset)),        50);
+        assertEq(conduit.withdrawableFunds(address(asset1), ilk1), 150);
+        assertEq(conduit.withdrawableFunds(address(asset1), ilk2), 300);
+        assertEq(conduit.totalWithdrawableFunds(address(asset1)),  450);
+        assertEq(conduit.withdrawals(address(asset1), ilk1),       50);
+        assertEq(conduit.withdrawals(address(asset1), ilk2),       0);
+        assertEq(conduit.totalWithdrawals(address(asset1)),        50);
 
-        // Finish withdraw ilk 1
+        // Finish withdraw ilk1 1
 
         vm.prank(operator1);
-        amount = conduit.withdraw(ilk1, address(asset), 150);
+        amount = conduit.withdraw(ilk1, address(asset1), 150);
 
         assertEq(amount, 150);
 
-        assertEq(asset.balanceOf(address(conduit)), 300);
-        assertEq(asset.balanceOf(operator1),        200);
-        assertEq(asset.balanceOf(operator2),        0);
+        assertEq(asset1.balanceOf(address(conduit)), 300);
+        assertEq(asset1.balanceOf(buffer1),          200);
+        assertEq(asset1.balanceOf(buffer2),          0);
 
-        assertEq(conduit.withdrawableFunds(address(asset), ilk1), 0);
-        assertEq(conduit.withdrawableFunds(address(asset), ilk2), 300);
-        assertEq(conduit.totalWithdrawableFunds(address(asset)),  300);
-        assertEq(conduit.withdrawals(address(asset), ilk1),       200);
-        assertEq(conduit.withdrawals(address(asset), ilk2),       0);
-        assertEq(conduit.totalWithdrawals(address(asset)),        200);
+        assertEq(conduit.withdrawableFunds(address(asset1), ilk1), 0);
+        assertEq(conduit.withdrawableFunds(address(asset1), ilk2), 300);
+        assertEq(conduit.totalWithdrawableFunds(address(asset1)),  300);
+        assertEq(conduit.withdrawals(address(asset1), ilk1),       200);
+        assertEq(conduit.withdrawals(address(asset1), ilk2),       0);
+        assertEq(conduit.totalWithdrawals(address(asset1)),        200);
 
-        // Full withdraw ilk 2
+        // Full withdraw ilk1 2
 
         vm.prank(operator2);
-        amount = conduit.withdraw(ilk2, address(asset), 300);
+        amount = conduit.withdraw(ilk2, address(asset1), 300);
 
         assertEq(amount, 300);
 
-        assertEq(asset.balanceOf(address(conduit)), 0);
-        assertEq(asset.balanceOf(operator1),        200);
-        assertEq(asset.balanceOf(operator2),        300);
+        assertEq(asset1.balanceOf(address(conduit)), 0);
+        assertEq(asset1.balanceOf(buffer1),          200);
+        assertEq(asset1.balanceOf(buffer2),          300);
 
-        assertEq(conduit.withdrawableFunds(address(asset), ilk1), 0);
-        assertEq(conduit.withdrawableFunds(address(asset), ilk2), 0);
-        assertEq(conduit.totalWithdrawableFunds(address(asset)),  0);
-        assertEq(conduit.withdrawals(address(asset), ilk1),       200);
-        assertEq(conduit.withdrawals(address(asset), ilk2),       300);
-        assertEq(conduit.totalWithdrawals(address(asset)),        500);
+        assertEq(conduit.withdrawableFunds(address(asset1), ilk1), 0);
+        assertEq(conduit.withdrawableFunds(address(asset1), ilk2), 0);
+        assertEq(conduit.totalWithdrawableFunds(address(asset1)),  0);
+        assertEq(conduit.withdrawals(address(asset1), ilk1),       200);
+        assertEq(conduit.withdrawals(address(asset1), ilk2),       300);
+        assertEq(conduit.totalWithdrawals(address(asset1)),        500);
     }
 
 }


### PR DESCRIPTION
Large PR, but actually quite simple in essence. No smart contract changes, only testing more realistically.

Previously this test suite used the `operator` as a "buffer". This made for easier testing but is not reflective of how the system is intended to be used and therefore is misleading for auditors. So, the following changes were made:

1. Refactor test base to use buffers, and infinite approve the conduit from them
2. Use multi-asset multi-ilk set up by default in base
3. Simplify helper functions based on this common setup
4. In all deposits, no longer `approve` from the `operator`, because that is not needed, funds come from `buffer`
5. Mint funds into `buffer` instead of `operator`
6. Remove code for specific multi-ilk/multi-asset setups in tests that were made redundant by common setup
7. Assert balance changes of `buffer` instead of `operator`

Note that the tests essentially work in the exact same way, they now just pull and push funds to the `buffer` instead of the `operator`.